### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ Policy options (listed by `sid`) are:
 * Restrict Regional Operations (LimitRegions)
 * Require S3 encryption (DenyIncorrectEncryptionHeader + DenyUnEncryptedObjectUploads)
 
-
-## Terraform Versions
-
-_This is how we're managing the different versions._
-Terraform 0.12. Pin module version to ~> 2.0. Submit pull-requests to master branch.
-
-Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform011 branch.
-
 ### Usage for combined policy statements
 
 To include a policy in your combined policy block, set it to `true`. Otherwise omit the policy variable.


### PR DESCRIPTION
When I pulled the policy info from the `org-scp` module to make this, I accidentally left the version statement in which is confusing. 

This just removes the whole `Terraform Versions` section bc we only tolerate terraform 12 around here anyhow. 