### PR TITLE
Mdawn make buckets sacred 174343953

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Policy options (listed by `sid`) are:
 * Deny deleting VPC Flow logs, Cloudwatch log groups, and Cloudwatch log streams (DenyDeletingCloudwatchLogs)
 * Deny root account (DenyRootAccount)
 * Protect S3 Buckets (ProtectS3Buckets)
+* Protect S3 Bucket Access ()
 * Protect IAM Roles (ProtectIAMRoles)
 * Restrict Regional Operations (LimitRegions)
 * Require S3 encryption (DenyIncorrectEncryptionHeader + DenyUnEncryptedObjectUploads)
@@ -48,6 +49,10 @@ module "github_terraform_aws_ou_scp" {
     "arn:aws:s3:::prod-terraform-state-us-west-2",
     "arn:aws:s3:::prod-terraform-state-us-west-2/*"
   ]
+
+  # don't allow public access to bucket resources
+  #
+  deny_s3_bucket_access = true
 
   protect_iam_roles             = true
   # - protect OrganizationAccountAccessRole
@@ -103,6 +108,7 @@ module "github_terraform_aws_ou_scp" {
 | deny\_deleting\_route53\_zones | DenyDeletingRoute53Zones in the OU policy. | `bool` | `false` | no |
 | deny\_leaving\_orgs | DenyLeavingOrgs in the OU policy. | `bool` | `false` | no |
 | deny\_root\_account | DenyRootAccount in the OU policy. | `bool` | `false` | no |
+| deny\_s3\_bucket\_access | S3 bucket resource ARNs to block public access to resources | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | limit\_regions | LimitRegions in the OU policy. | `bool` | `false` | no |
 | protect\_iam\_role\_resources | IAM role resource ARNs to protect from modification and deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_iam\_roles | ProtectIAMRoles in the OU policy. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Policy options (listed by `sid`) are:
 * Deny deleting VPC Flow logs, Cloudwatch log groups, and Cloudwatch log streams (DenyDeletingCloudwatchLogs)
 * Deny root account (DenyRootAccount)
 * Protect S3 Buckets (ProtectS3Buckets)
-* Protect S3 Bucket Access ()
+* Deny S3 Buckets Public Access (DenyS3BucketsPublicAccess)
 * Protect IAM Roles (ProtectIAMRoles)
 * Restrict Regional Operations (LimitRegions)
 * Require S3 encryption (DenyIncorrectEncryptionHeader + DenyUnEncryptedObjectUploads)
@@ -50,9 +50,11 @@ module "github_terraform_aws_ou_scp" {
     "arn:aws:s3:::prod-terraform-state-us-west-2/*"
   ]
 
-  # don't allow public access to bucket resources
-  #
-  deny_s3_bucket_access = true
+  # don't allow public access to bucket
+  deny_s3_bucket_public_access = true
+  deny_s3_bucket_public_access_resources = [
+    "arn:aws:s3:::log-delivery-august-2020"
+  ]
 
   protect_iam_roles             = true
   # - protect OrganizationAccountAccessRole
@@ -108,7 +110,8 @@ module "github_terraform_aws_ou_scp" {
 | deny\_deleting\_route53\_zones | DenyDeletingRoute53Zones in the OU policy. | `bool` | `false` | no |
 | deny\_leaving\_orgs | DenyLeavingOrgs in the OU policy. | `bool` | `false` | no |
 | deny\_root\_account | DenyRootAccount in the OU policy. | `bool` | `false` | no |
-| deny\_s3\_bucket\_access | S3 bucket resource ARNs to block public access to resources | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| deny\_s3\_bucket\_public\_access\_resources | S3 bucket resource ARNs to block public access | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| deny\_s3\_buckets\_public\_access | DenyS3BucketsPublicAccess in the OU policy. | `bool` | `false` | no |
 | limit\_regions | LimitRegions in the OU policy. | `bool` | `false` | no |
 | protect\_iam\_role\_resources | IAM role resource ARNs to protect from modification and deletion | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | protect\_iam\_roles | ProtectIAMRoles in the OU policy. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   deny_deleting_cloudwatch_logs_statement    = var.deny_deleting_cloudwatch_logs ? [""] : []
   deny_root_account_statement                = var.deny_root_account ? [""] : []
   protect_s3_buckets_statement               = var.protect_s3_buckets ? [""] : []
-  deny_s3_bucket_access_statement            = var.deny_s3_bucket_access ? [""] : []
+  deny_s3_buckets_public_access_statement    = var.deny_s3_buckets_public_access ? [""] : []
   protect_iam_roles_statement                = var.protect_iam_roles ? [""] : []
   limit_regions_statement                    = var.limit_regions ? [""] : []
   deny_unencrypted_object_uploads_statement  = var.require_s3_encryption ? [""] : []
@@ -148,18 +148,19 @@ data "aws_iam_policy_document" "combined_policy_block" {
 
 
   #
-  # Deny S3 Bucket Access (will not override an account-level setting)
+  # Deny S3 Buckets Public Access (will not override an account-level setting)
   #
 
   dynamic "statement" {
-    for_each = local.deny_s3_bucket_access_statement
+    for_each = local.deny_s3_buckets_public_access_statement
     content {
-      sid    = "DenyS3BucketAccess"
+      sid    = "DenyS3BucketsPublicAccess"
       effect = "Deny"
       actions = [
         "s3:PutBucketPublicAccessBlock",
+        "s3:DeletePublicAccessBlock"
       ]
-      resources = var.deny_s3_bucket_access
+      resources = var.deny_s3_bucket_public_access_resources
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ locals {
   deny_deleting_cloudwatch_logs_statement    = var.deny_deleting_cloudwatch_logs ? [""] : []
   deny_root_account_statement                = var.deny_root_account ? [""] : []
   protect_s3_buckets_statement               = var.protect_s3_buckets ? [""] : []
+  deny_s3_bucket_access_statement            = var.deny_s3_bucket_access ? [""] : []
   protect_iam_roles_statement                = var.protect_iam_roles ? [""] : []
   limit_regions_statement                    = var.limit_regions ? [""] : []
   deny_unencrypted_object_uploads_statement  = var.require_s3_encryption ? [""] : []
@@ -145,9 +146,31 @@ data "aws_iam_policy_document" "combined_policy_block" {
     }
   }
 
+
+  #
+  # Deny S3 Bucket Access (will not override an account-level setting)
+  #
+
+
+  dynamic "statement" {
+    for_each = local.deny_s3_bucket_access_statement
+    content {
+      sid    = "DenyS3BucketAccess"
+      effect = "Deny"
+      actions = [
+        "s3:PutBucketPublicAccessBlock",
+      ]
+      resources = var.deny_s3_bucket_access
+    }
+  }
+
+
+
+
   #
   # Protect IAM Roles
   #
+
   dynamic "statement" {
     for_each = local.protect_iam_roles_statement
     content {

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,6 @@ data "aws_iam_policy_document" "combined_policy_block" {
   # Deny S3 Bucket Access (will not override an account-level setting)
   #
 
-
   dynamic "statement" {
     for_each = local.deny_s3_bucket_access_statement
     content {
@@ -163,9 +162,6 @@ data "aws_iam_policy_document" "combined_policy_block" {
       resources = var.deny_s3_bucket_access
     }
   }
-
-
-
 
   #
   # Protect IAM Roles

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "protect_s3_buckets" {
   type        = bool
 }
 
+variable "deny_s3_buckets_public_access" {
+  description = "DenyS3BucketsPublicAccess in the OU policy."
+  default     = false
+  type        = bool
+}
+
 variable "protect_iam_roles" {
   description = "ProtectIAMRoles in the OU policy."
   default     = false
@@ -82,8 +88,8 @@ variable "protect_s3_bucket_resources" {
   default     = [""]
 }
 
-variable "deny_s3_bucket_access" {
-  description = "S3 bucket resource ARNs to block public access to resources"
+variable "deny_s3_bucket_public_access_resources" {
+  description = "S3 bucket resource ARNs to block public access"
   type        = list(string)
   default     = [""]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,12 @@ variable "protect_s3_bucket_resources" {
   default     = [""]
 }
 
+variable "deny_s3_bucket_access" {
+  description = "S3 bucket resource ARNs to block public access to resources"
+  type        = list(string)
+  default     = [""]
+}
+
 variable "protect_iam_role_resources" {
   description = "IAM role resource ARNs to protect from modification and deletion"
   type        = list(string)


### PR DESCRIPTION
# [keep buckets private](https://www.pivotaltracker.com/story/show/174343953)

Changes proposed in this pull request:

- Adds policy statement to block tampering with public access for a given bucket (blocks `PUT` & `DELETE`, I figure the GET is okay)
- Adds var for the bucket ARNs

Based off link in ticket &:
https://aws.amazon.com/blogs/aws/amazon-s3-block-public-access-another-layer-of-protection-for-your-accounts-and-buckets/
