### PR TITLE
Adding S3 KMS as encryption option for S3 SCP

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "combined_policy_block" {
       condition {
         test     = "StringNotEquals"
         variable = "s3:x-amz-server-side-encryption"
-        values   = ["AES256"]
+        values   = ["AES256", "aws:kms"]
       }
     }
   }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add KMS as an S3 encryption option

S3 supports SSE-S3, SSE-KMS, and SSE-C. This PR is to add support for SSE-KMS and I believe SSE-C. SSE-C uses the same header in addition to headers for specifying the customer KMS key. My opinion is the SCP should enforce the `x-amz-server-side-encryption` header and let AWS reject it if the customer KMS key is not provided. This still ensures only encrypted items are uploaded and thus the spirit of the SCP. https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html

Additional SSE types need to be supported as some services only use KMS such as Kinesis for encrypted payloads.
