### PR TITLE
add inactive issue workflow

### DIFF
--- a/.github/workflows/inactive_issue.yml
+++ b/.github/workflows/inactive_issue.yml
@@ -1,0 +1,19 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## [Tracker Story](<URL>)

Changes proposed in this pull request:

- add inactive issue GitHub workflow. Issues older than 30 days will be marked stale and issues with no activity for 14 days after being marked stale will be closed
