### PR TITLE
Update limit_regions to allow users to change support plans or submit support tickets in sub accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,6 +264,8 @@ data "aws_iam_policy_document" "combined_policy_block" {
         "shield:*",
         "sts:*",
         "support:*",
+        "supportapp:*",
+        "supportplans:*",
         "trustedadvisor:*",
         "waf-regional:*",
         "waf:*",


### PR DESCRIPTION
Without supportapp or supportplans users are unable to change a sub-accounts support plan level nor are they able to submit support tickets if the limit_regions policy is enabled.

Changes proposed in this pull request:

- Add `supportapp:*`  to LimitRegions statement
- Add `supportplans:*`  to LimitRegions statement
