### PR TITLE
fix: Allow chatbot because it's a global service in us-east-2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -237,6 +237,7 @@ data "aws_iam_policy_document" "combined_policy_block" {
         "aws-portal:*",
         "budgets:*",
         "ce:*",
+        "chatbot:*",
         "chime:*",
         "cloudfront:*",
         "config:*",


### PR DESCRIPTION
This PR updates `limit_regions` to allow AWS Chatbot.

AWS Chatbot seems to be a global service operating mainly from `us-east-2`: https://docs.aws.amazon.com/chatbot/latest/adminguide/chatbot-troubleshooting.html
It's also listed as exempt in the Control Tower Region-Deny policy: https://docs.aws.amazon.com/controltower/latest/userguide/primary-region-deny-policy.html