### PR TITLE
Omit ecr-public from SCP limiting regions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -246,6 +246,7 @@ data "aws_iam_policy_document" "combined_policy_block" {
         "ec2:DescribeRegions",
         "ec2:DescribeTransitGateways",
         "ec2:DescribeVpnGateways",
+        "ecr-public:*",
         "fms:*",
         "globalaccelerator:*",
         "health:*",


### PR DESCRIPTION
The SCP for limiting regions was preventing use of public ECR repos. We noticed this issue when attempting to retrieve ECR public credentials using this AWS data source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecrpublic_authorization_token

The AWS docs do not include this statement in their example SCP as is referenced in the codebase. https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples_general.html